### PR TITLE
Feature: add `dijkstra_sssp_weighted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-# Added
+### Added
 
 - Add `dijkstra_sssp_weighted`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+# Added
+
+- Add `dijkstra_sssp_weighted`.
+
+### Changed
+
+- Test `DijkstraWeighted.dijkstra_sssp_weighted` for every source vertex.
+- Make `CHANGELOG.md` adhere to [keep a changelog](https://keepachangelog.com/en/1.0.0/).
+
 ## [0.2.2] - 2024-03-31
 
 ### Added

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -9,5 +9,8 @@ pub use {
         dijkstra_sssp_unweighted,
         DijkstraUnweighted,
     },
-    dijkstra_weighted::DijkstraWeighted,
+    dijkstra_weighted::{
+        dijkstra_sssp_weighted,
+        DijkstraWeighted,
+    },
 };


### PR DESCRIPTION
# Added

- Add `dijkstra_sssp_weighted`.

### Changed

- Test `DijkstraWeighted.dijkstra_sssp_weighted` for every source vertex.
- Make `CHANGELOG.md` adhere to [keep a changelog](https://keepachangelog.com/en/1.0.0/).